### PR TITLE
Add basic project Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,8 @@ install:
 
 .PHONY: docs
 docs: $(INSTALL_SENTINEL)
-	$(RUN) mkdocs build
+	$(RUN) sphinx-apidoc -o docs src/dm_bip/ --ext-autodoc -f
+	$(RUN) sphinx-build -b html docs docs/_build
 
 
 ### Testing ###
@@ -77,6 +78,7 @@ clean:
 	rm -rf `find . -name __pycache__`
 	rm -rf .ruff_cache
 	rm -rf .pytest_cache
+	rm -rf docs/_build
 	rm -rf $(VENV)
 
 .PHONY: clobber

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,72 @@
+MAKEFLAGS += --no-builtin-rules
+MAKEFLAGS += --no-builtin-variables
+
+VENV := .venv
+INSTALL_SENTINEL := $(VENV)/.install.success
+VERSION := $(shell poetry version -s)
+PYTHON := $(VENV)/bin/python
+
+LINT_EXCLUDES := tests/input tests/output
+
+RUN := poetry run
+
+
+### Installation and Setup ###
+
+.PHONY: all
+all: $(INSTALL_SENTINEL) docs
+
+.PHONY: fresh
+fresh: clean clobber all
+
+
+$(INSTALL_SENTINEL): poetry.lock
+	poetry install --with dev --with docs
+	touch $@
+
+$(PYTHON): $(INSTALL_SENTINEL)
+
+
+### Documentation ###
+
+.PHONY: docs
+docs: $(INSTALL_SENTINEL)
+	$(RUN) mkdocs build
+
+
+### Testing ###
+
+.PHONY: test
+test: $(PYTHON)
+	$(RUN) pytest tests
+
+
+### Linting, Formatting, and Cleaning ###
+
+.PHONY: clean
+clean:
+	rm -f `find . -type f -name '*.py[co]'`
+	rm -rf `find . -name __pycache__`
+	rm -rf .ruff_cache
+	rm -rf .pytest_cache
+	rm -rf $(VENV)
+
+.PHONY: clobber
+clobber:
+
+
+.PHONY: lint
+lint: $(PYTHON)
+	-$(RUN) ruff check --diff src/ tests/ --exclude $(LINT_EXCLUDES)
+	-$(RUN) ruff format --check --diff --exclude $(LINT_EXCLUDES)
+
+
+.PHONY: format
+format: $(PYTHON)
+	-$(RUN) ruff check --fix src/ tests/ --exclude $(LINT_EXCLUDES)
+	-$(RUN) ruff format src/ tests/ --exclude $(LINT_EXCLUDES)
+
+.PHONY: coverage
+coverage: $(PYTHON)
+	$(RUN) coverage run -m pytest tests
+	$(RUN) coverage report -m

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,8 @@ $(INSTALL_SENTINEL): poetry.lock
 $(PYTHON): $(INSTALL_SENTINEL)
 
 .PHONY: install
-install: $(INSTALL_SENTINEL)
+install:
+	poetry install --with dev --with docs
 
 
 ### Documentation ###

--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,35 @@ LINT_EXCLUDES := tests/input tests/output
 
 RUN := poetry run
 
+### Help ###
+.PHONY: help
+help:
+	@echo "╭───────────────────────────────────────────────────────────╮"
+	@echo "│ Makefile for dm-bip                                       │"
+	@echo "│ ────────────────────────                                  │"
+	@echo "│ Usage:                                                    │"
+	@echo "│     make <target>                                         │"
+	@echo "│                                                           │"
+	@echo "│ Targets:                                                  │"
+	@echo "│     help                Print this help message           │"
+	@echo "│     all                 Install everything                │"
+	@echo "│     fresh               Clean and install everything      │"
+	@echo "│     clean               Clean up build artifacts          │"
+	@echo "│     clobber             Clean up generated files          │"
+	@echo "│                                                           │"
+	@echo "│     install             Set up the virtual environment    |"
+	@echo "│     docs                Generate documentation            │"
+	@echo "│     test                Run tests                         │"
+	@echo "│     lint                Lint all code                     │"
+	@echo "│     format              Format all code                   │"
+	@echo "│     coverage            Measure and report test coverage  │"
+	@echo "╰───────────────────────────────────────────────────────────╯"
+
 
 ### Installation and Setup ###
 
 .PHONY: all
-all: $(INSTALL_SENTINEL) docs
+all: install
 
 .PHONY: fresh
 fresh: clean clobber all
@@ -25,6 +49,9 @@ $(INSTALL_SENTINEL): poetry.lock
 	touch $@
 
 $(PYTHON): $(INSTALL_SENTINEL)
+
+.PHONY: install
+install: $(INSTALL_SENTINEL)
 
 
 ### Documentation ###


### PR DESCRIPTION
This has been late coming because I had been writing a good deal of code to implement the pipeline in Make. For various reasons, I think we are moving away from that idea, towards an interactive pipeline runner. This is all of the make functionality we need for project management (setting up an environment, linting, running tests).

There's one thing in here that may look a little strange: the $(INSTALL_SENTINEL) line. What this is doing is touching a file whenever poetry install was run successfully. Whenever poetry.lock has a newer update time than that file (or if that file does not exist), then `poetry install` will be run for any recipes that declare $(PYTHON) as a dependency. In practice, that means you do not have to worry about manually creating a virtual environment when running other targets (like `make test` or `make lint`, which require `pytest` and `ruff` to be installed, respectively).