### PR TITLE
Add docstrings to updated_flatten_to_tsv.py

### DIFF
--- a/src/dm_bip/format_converter/updated_flatten_to_tsv.py
+++ b/src/dm_bip/format_converter/updated_flatten_to_tsv.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 import pandas as pd
 import yaml
-from linkml_runtime.utils.scherecumaview import SchemaView
+from linkml_runtime.utils.schemaview import SchemaView
 from linkml_runtime.utils.yamlutils import YAMLRoot
 
 


### PR DESCRIPTION
The nested methods are missing docstrings and this is causing issues with tests and installing the project

```
File: "/Users/twhetzel/TEST_dm-bip/src/dm_bip/format_converter/updated_flatten_to_tsv.py"
 - No docstring for `collect_instances_by_class.recurse`
 - No docstring for `main.walk`
 Needed: 11; Found: 9; Missing: 2; Coverage: 81.8%
...
docstr-coverage: FAIL code 1 (1.30=setup[0.93]+cmd[0.37] seconds)
```