### PR TITLE
Add CONFIG include support to pipeline Makefile

### DIFF
--- a/pipeline.Makefile
+++ b/pipeline.Makefile
@@ -17,7 +17,12 @@ RUN := uv run
 #
 # All other variables are derived from these.
 
-
+# External config file support
+# ============
+# Use CONFIG=path/to/file.mk to load variables from an external file.
+# The config file should set variables using make syntax (e.g., DM_INPUT_DIR = /path).
+CONFIG ?=
+-include $(CONFIG)
 
 # Configurable parameters via environment variables
 # ============


### PR DESCRIPTION
## Summary
- Adds standard make idiom for external config file support
- Uses `-include` which silently skips if CONFIG is empty or file doesn't exist
- Enables dependent repos to define study-specific configs

## Usage
```bash
make CONFIG=path/to/study-config.mk
```

Fixes #237

## Test plan
- [x] All 68 tests pass
- [x] Verified config override works: `DM_SCHEMA_NAME` from config file correctly overrides default

🤖 Generated with [Claude Code](https://claude.com/claude-code)