### PR TITLE
Suppress linkml_runtime INFO log spam

### DIFF
--- a/src/dm_bip/map_data/map_data.py
+++ b/src/dm_bip/map_data/map_data.py
@@ -260,4 +260,5 @@ if __name__ == "__main__":
         level=logging.INFO,
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     )
+    logging.getLogger("linkml_runtime").setLevel(logging.WARNING)
     typer.run(main)


### PR DESCRIPTION
## Summary
- Suppress verbose INFO messages from linkml_runtime that clutter pipeline output
- Sets linkml_runtime logger to WARNING level in map_data.py

## Test plan
- [ ] Run pipeline and verify no more "Importing linkml:types" spam messages
- [ ] Verify WARNING and ERROR messages from linkml_runtime still appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)