### PR TITLE
Skip prepare step for debug targets

### DIFF
--- a/pipeline.Makefile
+++ b/pipeline.Makefile
@@ -86,9 +86,13 @@ MAPPING_SUCCESS_SENTINEL := $(MAPPING_OUTPUT_DIR)/_mapping_complete
 
 # Include prepared input file list if it exists
 # Make's automatic remake will generate this when DM_RAW_SOURCE is set
-# Skip for debug targets to avoid triggering the prepare step
+# Skip only when ALL requested goals are debug/help targets
 DEBUG_TARGETS := pipeline-debug map-debug schema-debug validate-debug help
-ifeq ($(filter $(DEBUG_TARGETS),$(MAKECMDGOALS)),)
+ifneq ($(strip $(filter-out $(DEBUG_TARGETS),$(MAKECMDGOALS))),)
+ifdef DM_RAW_SOURCE
+-include $(PREPARED_INPUT_MK)
+endif
+else ifeq ($(strip $(MAKECMDGOALS)),)
 ifdef DM_RAW_SOURCE
 -include $(PREPARED_INPUT_MK)
 endif


### PR DESCRIPTION
## Summary
- Guard the `$(PREPARED_INPUT_MK)` include so it's skipped when running debug/help targets (`pipeline-debug`, `map-debug`, `schema-debug`, `validate-debug`, `help`)
- Previously, `make pipeline-debug` with `DM_RAW_SOURCE` set would trigger the full prepare step before printing anything

Refs #247

## Test plan
- [x] CI passes
- [ ] `make pipeline-debug CONFIG=...` with `DM_RAW_SOURCE` set prints immediately without preparing files

🤖 Generated with [Claude Code](https://claude.com/claude-code)