### PR TITLE
Switch trans-specs to bdc-harmonized-variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,6 @@ COPY . ./
 
 # Clone external repos (shallow, single layer)
 RUN git clone --depth 1 --branch v1.1.0 https://github.com/RTIInternational/NHLBI-BDC-DMC-HM.git && \
-    git clone --depth 1 --branch v1.0.0 https://github.com/RTIInternational/NHLBI-BDC-DMC-HV.git
+    git clone --depth 1 https://github.com/amc-corey-cox/bdc-harmonized-variables.git
 
 CMD ["uv", "run", "dm-bip", "run"]

--- a/scripts/workflow/bdc-workflow.sh
+++ b/scripts/workflow/bdc-workflow.sh
@@ -141,7 +141,14 @@ DM_OUTPUT_DIR="${HOME}/${OUTPUT_NAME}"
 DM_INPUT_DIR="${HOME}/${RAW_DIR_NAME}_CleanedSource"
 
 # Define paths to external dependencies (within container)
-DM_TRANS_SPEC_DIR="/app/NHLBI-BDC-DMC-HV/priority_variables_transform/${DM_SCHEMA_NAME}-ingest"
+# Find the latest version directory for this study's trans-specs
+TRANS_SPEC_BASE="/app/bdc-harmonized-variables/trans_specs/${DM_SCHEMA_NAME}"
+DM_TRANS_SPEC_DIR=$(find "$TRANS_SPEC_BASE" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort | tail -1)
+if [[ -z "$DM_TRANS_SPEC_DIR" ]]; then
+  echo "ERROR: No trans-spec version directory found under $TRANS_SPEC_BASE"
+  exit 1
+fi
+echo "  Trans-spec version:   $(basename "$DM_TRANS_SPEC_DIR")"
 DM_MAP_TARGET_SCHEMA="/app/NHLBI-BDC-DMC-HM/src/bdchm/schema/bdchm.yaml"
 
 echo ""


### PR DESCRIPTION
## Summary

- Swap `NHLBI-BDC-DMC-HV` for `bdc-harmonized-variables` repo in Dockerfile
- Update `bdc-workflow.sh` to auto-select the latest version directory under each study's trans-specs
- Target schema (HM) unchanged

## Test plan

- [ ] CI passes (Docker smoke test builds container)
- [ ] Deploy to BDC via docker-dev and run FHS pipeline
- [ ] Verify trans-spec version auto-detection picks up latest (FHS-v35)

🤖 Generated with [Claude Code](https://claude.com/claude-code)