### PR TITLE
Bump pinned tags for release repos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,8 @@ RUN if [ "$BDC_PULL_LATEST" = "true" ]; then \
       git clone --depth 1 https://github.com/RTIInternational/NHLBI-BDC-DMC-HM.git && \
       git clone --depth 1 https://github.com/amc-corey-cox/bdc-harmonized-variables.git; \
     else \
-      git clone --depth 1 --branch v1.1.0 https://github.com/RTIInternational/NHLBI-BDC-DMC-HM.git && \
-      git clone --depth 1 --branch 2026.03-2-rc1 https://github.com/amc-corey-cox/bdc-harmonized-variables.git; \
+      git clone --depth 1 --branch v1.2.0 https://github.com/RTIInternational/NHLBI-BDC-DMC-HM.git && \
+      git clone --depth 1 --branch 2026.03-2 https://github.com/amc-corey-cox/bdc-harmonized-variables.git; \
     fi
 
 CMD ["uv", "run", "dm-bip", "run"]


### PR DESCRIPTION
## Summary
- NHLBI-BDC-DMC-HM: v1.1.0 → v1.2.0
- bdc-harmonized-variables: 2026.03-2-rc1 → 2026.03-2

These are the pinned tags used in prod builds (BDC_PULL_LATEST=false).