### PR TITLE
Migrate docs deployment workflow from Poetry to uv

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -9,35 +9,31 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3.0.2
+      uses: actions/checkout@v4
       with:
-        fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+        fetch-depth: 0
 
-    - name: Set up Python 3.
-      uses: actions/setup-python@v3
-      with:
-        python-version: 3.13
+    - name: Install uv
+      uses: astral-sh/setup-uv@v3
 
-    - name: Install Poetry.
-      uses: snok/install-poetry@v1.3.1
+    - name: Install Python
+      run: uv python install 3.13
 
-    - name: Install dependencies.
+    - name: Install dependencies
+      run: uv sync --group docs
+
+    - name: Build documentation
       run: |
-        poetry install --with docs
-
-    - name: Build documentation.
-      run: |
-        echo ${{ secrets.GITHUB_TOKEN }} >> src/dm_bip/token.txt
         mkdir gh-pages
         touch gh-pages/.nojekyll
         cd docs/
-        poetry run sphinx-apidoc -o . ../src/dm_bip/ --ext-autodoc -f
-        poetry run sphinx-build -b html . _build
+        uv run sphinx-apidoc -o . ../src/dm_bip/ --ext-autodoc -f
+        uv run sphinx-build -b html . _build
         cp -r _build/* ../gh-pages/
 
-    - name: Deploy documentation.
+    - name: Deploy documentation
       if: ${{ github.event_name == 'push' }}
-      uses: JamesIves/github-pages-deploy-action@v4.4.1
+      uses: JamesIves/github-pages-deploy-action@v4
       with:
         branch: gh-pages
         force: true


### PR DESCRIPTION
## Summary

- Replace Poetry with uv in the docs deployment workflow
- Update actions to current versions (checkout@v4, setup-uv@v3, github-pages-deploy-action@v4)
- Remove mysterious `token.txt` write that was leaking GITHUB_TOKEN into the source tree during builds

Closes #180