### PR TITLE
Declare typer as a direct dependency (#327)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "pandas>=2.2.3,<3",
     "schema-automator==0.5.5",
     "linkml-map==0.5.2",
+    "typer>=0.20.0,<1",
     "typing-extensions>=4.0,<5",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -758,6 +758,7 @@ dependencies = [
     { name = "linkml-map" },
     { name = "pandas" },
     { name = "schema-automator" },
+    { name = "typer" },
     { name = "typing-extensions" },
 ]
 
@@ -787,6 +788,7 @@ requires-dist = [
     { name = "linkml-map", specifier = "==0.5.2" },
     { name = "pandas", specifier = ">=2.2.3,<3" },
     { name = "schema-automator", specifier = "==0.5.5" },
+    { name = "typer", specifier = ">=0.20.0,<1" },
     { name = "typing-extensions", specifier = ">=4.0,<5" },
 ]
 


### PR DESCRIPTION
## Summary

`typer` is used throughout the codebase (`src/dm_bip/cli.py`, `src/dm_bip/seven_bridges/cli.py`, `scripts/workflow/`, etc.) but was only resolved transitively via `uv.lock`. This declares it as a direct dependency so a future change to another dep can't silently drop the transitive route and break the CLIs.

## Changes

- Add `typer>=0.20.0,<1` to `dependencies` in `pyproject.toml`
- Relock (`uv lock`) — typer version is unchanged (`0.20.0` was already locked); only the dependency edges change

Verified with a fresh `uv sync` and `dm-bip --help`.

Closes #327