### PR TITLE
Wire DM_MAP_PROFILE through bdc-workflow.sh

### DIFF
--- a/scripts/workflow/bdc-workflow.sh
+++ b/scripts/workflow/bdc-workflow.sh
@@ -59,6 +59,8 @@ Optional Parameters:
   --trans-spec  Alternate trans-spec source (OWNER/REPO[@REF][:PATH])
   --workdir     Working directory for pipeline execution (default: /app)
   --jobs        Number of parallel make jobs (default: 8)
+  --profile     Enable map-step diagnostics (py-spy CPU profile + cgroup
+                memory/OOM); see docs/map-diagnostics.md
 
 Examples:
   $0 --schema FHS --source /data/raw/fhs_study
@@ -78,6 +80,10 @@ DM_RAW_SOURCE=""
 TRANS_SPEC_SLUG=""
 WORKING_DIR="/app"  # Default working directory
 MAKE_JOBS=8         # Default parallel jobs
+# Map-step diagnostics (py-spy CPU profile + cgroup memory/OOM); see
+# docs/map-diagnostics.md. Off by default; set via --profile or the
+# DM_MAP_PROFILE environment variable.
+DM_MAP_PROFILE="${DM_MAP_PROFILE:-false}"
 
 #------------------------------------------------------------------------------
 # 1. Parse Named Parameters
@@ -117,6 +123,10 @@ while [[ $# -gt 0 ]]; do
       fi
       MAKE_JOBS="$2"
       shift 2
+      ;;
+    --profile)
+      DM_MAP_PROFILE="true"
+      shift
       ;;
     -h|--help)
       usage 0
@@ -394,6 +404,7 @@ make -j "$MAKE_JOBS" pipeline \
   DM_TRANS_SPEC_DIR="$DM_TRANS_SPEC_DIR" \
   DM_MAP_TARGET_SCHEMA="$DM_MAP_TARGET_SCHEMA" \
   DM_REPO_MANIFEST="/app/repo-manifest.yaml" \
+  DM_MAP_PROFILE="$DM_MAP_PROFILE" \
   $DM_MAP_STRICT_ARG
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
#339 added the `DM_MAP_PROFILE` diagnostics toggle to `pipeline.Makefile`, but the BDC entry point (`bdc-workflow.sh`) never forwarded it — so map-step diagnostics were **unreachable on real data**, which is the one place they matter (you can't reproduce these OOM/perf issues off toy data).

This adds a `--profile` flag (plus a `DM_MAP_PROFILE` env fallback) that forwards `DM_MAP_PROFILE=true` to the `make pipeline` call, mirroring how `DM_MAP_STRICT` is handled. Off by default; zero effect when unset.

**Still needed to use it per-task on SBG:** the CWL app has to expose it — either a `profile` boolean input mapped to `--profile`, or an input mapped to the `DM_MAP_PROFILE` env var. This PR is the repo half; the app revision is the other half. (Left the env fallback in precisely so the app can plumb it whichever way is easier.)

Completes the BDC-reachability gap in #339.
