### PR TITLE
Bump default SBG app to cc-dm-bip-test/5

### DIFF
--- a/src/dm_bip/seven_bridges/client.py
+++ b/src/dm_bip/seven_bridges/client.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_BASE_URL = "https://api.sb.biodatacatalyst.nhlbi.nih.gov/v2"
 DEFAULT_PROJECT = "rmathur2/dmc-task-4-controlled"
-DEFAULT_APP = "rmathur2/dmc-task-4-controlled/cc-dm-bip-test/4"
+DEFAULT_APP = "rmathur2/dmc-task-4-controlled/cc-dm-bip-test/5"
 DEFAULT_TOKEN_FILE = Path.home() / ".sevenbridges" / "token"
 
 DEFAULT_TIMEOUT_SECONDS = 30.0


### PR DESCRIPTION
`client.py` still defaults to `cc-dm-bip-test/4`, which pulls the crossed pre-migration image (`vbakalov/...`). Revision `/5` pulls `vbakalov-era/dm-bip-docker-dev/dm-bip-env:latest` — the image `docker-dev` actually builds to. Bumps the committed default so `seven-bridges submit` targets the right container without an explicit `--app`.

## Test plan
- [x] `pytest tests/unit/seven_bridges/` — 21 passed
- [x] `ruff check` — clean