### PR TITLE
Ignore per-run task_logs_* dirs, not just the CLI default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,5 +155,7 @@ CLAUDE.local.md
 output/
 
 # Generated Seven Bridges task manifest + log dumps
+# --output-dir is routinely set to a per-run name (task_logs_c1_rc2, task_logs_control),
+# so match the suffixed variants too, not just the CLI default.
 /batch_tasks.csv
-/task_logs/
+/task_logs*/


### PR DESCRIPTION
The seven-bridges log ignore rule matched only `task_logs/` — the value of `DEFAULT_LOG_DIR` in `src/dm_bip/seven_bridges/cli.py`. But `--output-dir` is routinely given a per-run name so runs stay separable, and `/task_logs/` matches none of those. Sixteen `task_logs_*` dirs (~10MB) had piled up untracked in the repo root from the June/July map diagnostics runs.

`/task_logs*/` still matches the default and picks up the suffixed variants. Verified with `git check-ignore` against `task_logs/`, `task_logs_A/`, and `task_logs_c1_rc2/`.

Left alone deliberately: the hand-named batch manifests (`chs_c1.csv`, `chs_c4.csv`) hit the same problem against `/batch_tasks.csv`, but the only rule broad enough to catch arbitrary names is `/*.csv`, which would hide legitimate files. Also worth considering separately — having the CLI write to `task_logs/<run-name>/` so an overridden run name can't escape the rule by construction.